### PR TITLE
Fixed Null Pointer Exception when downloading a drive doc/sheet that …

### DIFF
--- a/src/main/java/jdrivesync/sync/Synchronization.java
+++ b/src/main/java/jdrivesync/sync/Synchronization.java
@@ -490,7 +490,7 @@ public class Synchronization {
 			private void performChecksumCheck(File file, SyncItem syncItem, com.google.api.services.drive.model.File remoteFile, boolean updateMetadata) {
 				String remoteFileMd5Checksum = remoteFile.getMd5Checksum();
 				String localFileMd5Checksum = computeMd5Checksum(file);
-				if (remoteFileMd5Checksum.equals(localFileMd5Checksum)) {
+				if (remoteFileMd5Checksum != null && remoteFileMd5Checksum.equals(localFileMd5Checksum)) {
 					syncItem.setLocalFile(Optional.of(file));
 					if (!updateMetadata) {
 						LOGGER.log(Level.FINE, "Not downloading file '" + syncItem.getPath() + "' because MD5 checksums are equal (local: " + localFileMd5Checksum + ", remote: " + remoteFileMd5Checksum + ").");


### PR DESCRIPTION
…exists on the local machine.

It appears that remote Google docs and sheet return a file size of 0. So, when comparing the sizes the local (converted to Open Office) document will always have a different size than the local copy. This causes the `performChecksumCheck()` to return `null` on the remote file, throws an exception and then skips the file. Since we don't know for sure if the remote file is different than the local file, I think it would be better to download the file again.

Another enhancement could be an additional parameter `--only-check-last-modified` so that the file size and checksum are not also validated. This would prevent downloading files that have the same modification date (but could potentially be different).

Here is the stack trace that this commit fixes:

```
2018-07-24 09:32:01 FINE jdrivesync.sync.Synchronization$2 processRemoteChildFound(): Skipping file '/MyFile because reading local file attributes failed: null
java.lang.NullPointerException
	at jdrivesync.sync.Synchronization$2.performChecksumCheck(Synchronization.java:493)
	at jdrivesync.sync.Synchronization$2.processRemoteChildFound(Synchronization.java:463)
	at jdrivesync.sync.Synchronization$2.visitDirectory(Synchronization.java:337)
	at jdrivesync.gdrive.GoogleDriveWalker.walkInternal(GoogleDriveWalker.java:88)
	at jdrivesync.gdrive.GoogleDriveWalker.walk(GoogleDriveWalker.java:35)
	at jdrivesync.sync.Synchronization.syncDown(Synchronization.java:321)
	at jdrivesync.App.sync(App.java:89)
	at jdrivesync.App.run(App.java:54)
	at jdrivesync.App.main(App.java:27)
```